### PR TITLE
Update the `es-abstract` dependency to version 1.14.1 from the unpublished version 1.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3327,9 +3327,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
-      "integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.1.tgz",
+      "integrity": "sha512-cp/Tb1oA/rh2X7vqeSOvM+TSo3UkJLX70eNihgVEvnzwAgikjkTFr/QVgRCaxjm0knCNQzNoxxxcw2zO2LJdZA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
@@ -6965,7 +6965,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "1.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
@@ -6974,7 +6974,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -7007,7 +7007,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -7036,7 +7036,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {


### PR DESCRIPTION
Rob and Michael Siegel reached out to me with an issue resulting from https://github.com/thoughtindustries/ti/pull/6544 that caused `npm install` to not complete – both were using a version of `npm` newer than version 6, which is what is bundled with the `ti` project’s expected Node.js version, 14. They were able to resolve their issue by installing and using `npm` version 6. However, this issue will need to be resolved before upgrading the `ti` project to a new major version of Node.js is possible.

```
npm ERR! npm ERR! code E404
npm ERR! npm ERR! 404 Not Found - GET https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz - Not found
npm ERR! npm ERR! 404 
npm ERR! npm ERR! 404  'es-abstract@https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz' is not in this registry.
npm ERR! npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! npm ERR! 404 
npm ERR! npm ERR! 404 Note that you can also install from a
npm ERR! npm ERR! 404 tarball, folder, http url, or git url.
```

There is no shortage of posts on the internet complaining about this – [the author of the package unpublished that version from the public registry](https://github.com/ljharb/es-abstract/issues/126).

However, when I `grep`ed our `package-lock.json` file, the oldest version referenced was `^1.17.0-next.0`. So I guessed that maybe an outdated _indirect_ dependency of `ti` was still referencing that version. `npm` includes a tool to visualize the dependency tree of your project, which pretty quickly shot a hole in that theory.

```
% npm list | grep "es-abstract"
│ │ │ │ ├── es-abstract@1.18.0 deduped
│ │ │ │ └── es-abstract@1.18.0 deduped
│ │ │ │ ├── es-abstract@1.18.0 deduped
│ │ │ │ ├── es-abstract@1.18.0 deduped
│ │ │ │ └─┬ es-abstract@1.18.3
│ │ │ │ ├── es-abstract@1.18.0 deduped
│ │ │ │ └── es-abstract@1.18.0 deduped
│ │ │ │ └─┬ es-abstract@1.18.3
│ │ │ │ │ ├── es-abstract@1.18.0 deduped
│ │ │ │ ├── es-abstract@1.18.0 deduped
│ │ │ │ ├─┬ es-abstract@1.18.3
│ │ │ │ ├─┬ es-abstract@1.18.3
│ │ │ │ └── es-abstract@1.18.0 deduped
│ │ │ │ └── es-abstract@1.18.0 deduped
│ │ │   ├── es-abstract@1.18.0 deduped
│   │ ├─┬ es-abstract@1.18.0
│     ├── es-abstract@1.18.0 deduped
```

Hmm … unless …

I dove deeper into the `npm` logs, and something (finally) stuck out to me …

```
npm ERR! code 1
npm ERR! git dep preparation failed
```

“_git_ deps,” you say? 🤨 I wondered if maybe the culprit was not an existing `npm` package, but one of `ti`’s `git://`–style dependencies.

Looking at [this repository’s `package-lock.json` file](https://github.com/thoughtindustries/ical-generator/blob/5fa4c8801bb69031defc5cb3c9c667b37d9bf348/package-lock.json#L3329-L3330), _it_ references version `1.14.0` of `es-abstract` (with no leading “`^`”)!

This pull request updates the `es-abstract` dependency to version 1.14.1 from the unpublished version 1.14.0.